### PR TITLE
Fix# 배포한 페이지에서 새로고침 시 404에러문제 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ prop drilling과 Context API를 비교 구현하며, 기본 CRUD 기능을 통�
 ---
 
 ## 🚀 배포
-- [ ] Vercel을 이용해 배포 완료
+- [x] Vercel을 이용해 배포 완료
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ prop drilling과 Context API를 비교 구현하며, 기본 CRUD 기능을 통�
 ## 🧪 도전 과제 (선택 사항)
 
 ### 🔄 Redux Toolkit 리팩터링
-- [ ] `redux-toolkits` 브랜치 생성
-- [ ] Redux Toolkit으로 포켓몬 선택 상태 관리
+- [x] `redux-toolkits` 브랜치 생성
+- [x] Redux Toolkit으로 포켓몬 선택 상태 관리
 
 ### ➕ 디테일 페이지에서 포켓몬 추가
 - [x] '추가' / '삭제' 버튼으로 상태 반영

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+    "rewrite":[
+        {
+            "source":"/(.*)",
+            "destination":"/index.html"
+        }
+    ]
+}


### PR DESCRIPTION
## 📋 변경 사항

- vercel.json를 만들어 모든 요청을 index.html파일로 다시 작성하도록 추가

## 📝 추가 사항

- React SPA는 모든 페이지가 index.html로 나타나고, 라우팅 처리를 통해 이동하는 방식
- 경로 이름에 해당하는 파일을 요청하는 것이 아닌 index.html에 컴포넌트를 렌더링하는 방식
- 실제 서버는 요청된 URL에 해당하는 파일을 찾게됨
- React SPA에서는 경로에 해당하는 파일을 만들지 않고 모든 라우팅을 index.html에서 하기 때문에 서버는 해당 경로의 파일을 찾지 못하고 404에러를 반환함
- 따라서 vercel.json에서 `./*` 들어오는 모든 경로를 index.html로 다시 작성하게 만듦